### PR TITLE
Implement basic error handling for duplicates

### DIFF
--- a/backend/question-service/controllers/questionsController.js
+++ b/backend/question-service/controllers/questionsController.js
@@ -9,8 +9,14 @@ const getAllQuestions = async (req, res) => {
 
 const createQuestion = async (req, res) => {
     if (!(req?.body?.title && req?.body?.description && req?.body?.category && req?.body?.complexity)) {
-        return res.status(400).json({ 'message': 'title, description, category and complexity are required!' });
-    }    
+        return res.status(400).json({ 'message': 'Title, description, category and complexity are required!' });
+    }
+    if (QuestionSchema.findOne({ title: req.body.title }).exec != null) {
+        return res.status(409).json({ 'message': 'A question with this title already exists!' })
+    }
+    if (QuestionSchema.findOne({ description: req.body.description }).exec != null) {
+        return res.status(409).json({ 'message': 'A question with this description already exists!' })
+    }
     try {
         const result = await QuestionSchema.create({
             title: req.body.title,

--- a/backend/question-service/controllers/questionsController.js
+++ b/backend/question-service/controllers/questionsController.js
@@ -11,10 +11,10 @@ const createQuestion = async (req, res) => {
     if (!(req?.body?.title && req?.body?.description && req?.body?.category && req?.body?.complexity)) {
         return res.status(400).json({ 'message': 'Title, description, category and complexity are required!' });
     }
-    if (QuestionSchema.findOne({ title: req.body.title }).exec != null) {
+    if (await QuestionSchema.countDocuments({ title: req.body.title }) > 0) {
         return res.status(409).json({ 'message': 'A question with this title already exists!' })
     }
-    if (QuestionSchema.findOne({ description: req.body.description }).exec != null) {
+    if (await QuestionSchema.countDocuments({ description: req.body.description }) > 0) {
         return res.status(409).json({ 'message': 'A question with this description already exists!' })
     }
     try {
@@ -25,7 +25,7 @@ const createQuestion = async (req, res) => {
             complexity: req.body.complexity
         });
 
-        res.status(201).json(result);
+        return res.status(201).json(result);
     } catch (err) {
         console.error(err);
     }

--- a/backend/question-service/controllers/questionsController.js
+++ b/backend/question-service/controllers/questionsController.js
@@ -56,6 +56,7 @@ const updateQuestion = async (req, res) => {
         return res.status(409).json({ 'message': 'A question with this title already exists!' })
     }
 
+    // Check for duplicate descriptions
     const currentDescription = await QuestionSchema.findById(req.body._id, 'description').exec()
     const duplicateDescCheck = (await QuestionSchema.countDocuments({ description: req.body.description }) > 1) || (await QuestionSchema.countDocuments({ description: req.body.description }) == 1 && currentDescription.description != req.body.description)
     if (duplicateDescCheck) {

--- a/backend/question-service/controllers/questionsController.js
+++ b/backend/question-service/controllers/questionsController.js
@@ -49,6 +49,19 @@ const updateQuestion = async (req, res) => {
         return res.status(401).json({ "message": `No question matches ID ${ questionId}.` });
     }
 
+    // Check for duplicate titles
+    const currentTitle = await QuestionSchema.findById(req.body._id, 'title').exec()
+    const duplicateTitleCheck = (await QuestionSchema.countDocuments({ title: req.body.title }) > 1) || (await QuestionSchema.countDocuments({ title: req.body.title }) == 1 && currentTitle.title != req.body.title)
+    if (duplicateTitleCheck) {
+        return res.status(409).json({ 'message': 'A question with this title already exists!' })
+    }
+
+    const currentDescription = await QuestionSchema.findById(req.body._id, 'description').exec()
+    const duplicateDescCheck = (await QuestionSchema.countDocuments({ description: req.body.description }) > 1) || (await QuestionSchema.countDocuments({ description: req.body.description }) == 1 && currentDescription.description != req.body.description)
+    if (duplicateDescCheck) {
+        return res.status(409).json({ 'message': 'A question with this description already exists!' })
+    }
+
     if (req.body?.title) question.title = req.body.title;
     if (req.body?.description) question.description = req.body.description;
     if (req.body?.category) question.category = req.body.category;

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -13,7 +13,7 @@ import "./styles/App.css"; // css file
 
 const HomePage = () => {
   const navigate = useNavigate();
-  const immediatelyDirectToQuestionPage = false; 
+  const immediatelyDirectToQuestionPage = true; 
 
   // Effect to handle navigation
   useEffect(() => {

--- a/frontend/src/pages/QuestionPage.jsx
+++ b/frontend/src/pages/QuestionPage.jsx
@@ -43,7 +43,6 @@ const QuestionPage = () => {
 
   // Add questions
   const handleAddQuestion = async (newQuestion) => {
-    toggleDialog();
 
     try {
       const response = await fetch("http://localhost:8080/questions", {
@@ -58,8 +57,13 @@ const QuestionPage = () => {
         const savedQuestion = await response.json();
         console.log("savedQuestion:", savedQuestion);
         setQuestions((prevQuestions) => [...prevQuestions, savedQuestion]);
+        toggleDialog();
       } else {
         console.error("Failed to add question");
+        var responseMessage = await response.json()
+        const errorWindow = window.alert(
+          responseMessage.message
+        );
       }
     } catch (error) {
       console.error("Error adding question:", error);

--- a/frontend/src/pages/QuestionPage.jsx
+++ b/frontend/src/pages/QuestionPage.jsx
@@ -111,16 +111,19 @@ const QuestionPage = () => {
             q._id === savedQuestion._id ? savedQuestion : q
           )
         );
+        toggleDialog();
       } else {
-        const errorMessage = await response.text();
         console.error(
-          `Failed to edit question: ${response.status} ${errorMessage}`
+          `Failed to edit question: ${response.status} ${response.statusText}`
+        );
+        var responseMessage = await response.json()
+        const errorWindow = window.alert(
+          responseMessage.message
         );
       }
     } catch (error) {
       console.error("Error editing question:", error);
     }
-    toggleDialog();
   };
 
   // Delete question


### PR DESCRIPTION
Implemented error handling to prevent questions with duplicate titles and descriptions.

Note: Duplicate detection is case sensitive for now, so two questions can have the same title if the cases for at least one letter is different.